### PR TITLE
Remove redundant command to build app in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_script:
   - php artisan set:client_secret .env
   - npm install
   - node_modules/.bin/tslint --project tsconfig.json
-  - npm run production
   - php artisan serve &
 
 script:


### PR DESCRIPTION
`npm run production` is already included as postscript after install.